### PR TITLE
Windows compatibility

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+*.go eol=lf
+go.mod eol=lf
+go.sum eol=lf

--- a/testdata/symlinks/invalid-symlink
+++ b/testdata/symlinks/invalid-symlink
@@ -1,1 +1,1 @@
-/non/existing/file
+non/existing/file

--- a/walk_test.go
+++ b/walk_test.go
@@ -254,9 +254,9 @@ func TestPostChildrenCallback(t *testing.T) {
 	}
 
 	expected := []string{
-		"testdata/dir5/a2/a2a",
-		"testdata/dir5/a2",
-		"testdata/dir5",
+		filepath.FromSlash("testdata/dir5/a2/a2a"),
+		filepath.FromSlash("testdata/dir5/a2"),
+		filepath.FromSlash("testdata/dir5"),
 	}
 
 	if got, want := len(actual), len(expected); got != want {


### PR DESCRIPTION
I encountered some problems with this package when it was pulled as a dependency of gopkgs. Trying to update gopkgs resulted in errors from git because the `invalid-symlink` file was modified during the checkout due to symlink behaviour in Git on Windows.

Making the `invalid-symlink` a relative symlink fixes the problem on Windows and doesn't appear to cause test failures. I did encounter some other unrelated test failures, which appear to be Windows-specific, that I have also fixed here.
