### PR TITLE
Callback option to ignore hidden directories and/or other specified...

### DIFF
--- a/walk.go
+++ b/walk.go
@@ -53,6 +53,18 @@ type Options struct {
 	// that refer to a directory.
 	FollowSymbolicLinks bool
 
+	// NoHidden (only UNIX) specifies whether Walk will follow hidden directories.
+	// When set to false or left as its zero-value, Walk will invoke the callback
+	// function and traverse into hidden directories too. When set to true, Walk
+	// will not traverse to hidden directories.
+	NoHidden bool
+
+	// Ignore represents a list of names for directories that should be ignored.
+	// When Walk is about to traverse a directory and directories name the same
+	// to a string in the Ignore list then that direcory with all its descendants
+	// is ignored. If is left empty as it is, it will be ignored by callback function.
+	Ignore []string
+
 	// Unsorted controls whether or not Walk will sort the immediate descendants
 	// of a directory by their relative names prior to visiting each of those
 	// entries.
@@ -280,6 +292,16 @@ func walk(osPathname string, dirent *Dirent, options *Options) error {
 	}
 
 	if !dirent.IsDir() {
+		return nil
+	}
+
+	for _, el := range options.Ignore {
+		if dirent.name == el {
+			return nil
+		}
+	}
+
+	if string(dirent.name[0]) == "." && options.NoHidden {
 		return nil
 	}
 


### PR DESCRIPTION
I created this simple modification to the Walk function, so that in the Callback options there are two more variables. A boolean (NoHidden), that if left as it is does not affect at all the main function, and a string slice (Ignore) that again if left as it is (empty) it just gets ignored by main function.

If boolean is set to true in Callback function, then the Walk ignores hidden files (only UNIX) and does not go through them. The same with the Ignore slice. If slice has a string the same as any folder name, then the Walk ignores that folder.

THIS IS MY FIRST EVER PULL REQUEST. 
I hope you be gentle if you think this is not worthy adding or is not to be considered.
I am using your library and is amazing, but i wanted to have control when to show hidden files and when to ignore them, and sometime to ignore just specified complex folders (looking at you node modules folder).

I just thought that if someone else wants to use, i might as-well contribute those mini lines of code.
Have nice day (and happy new year)