### PR TITLE
Fix removal of 'noaccess' test directory

### DIFF
--- a/scaffoling_test.go
+++ b/scaffoling_test.go
@@ -86,6 +86,9 @@ func setup(tb testing.TB) string {
 }
 
 func teardown(tb testing.TB, root string) {
+	if err := os.Chmod(filepath.Join(root, filepath.FromSlash("dir6/noaccess")), 0700); err != nil {
+		tb.Fatalf("cannot change permission to delete dir6/noaccess for test scaffolding: %s\n", err)
+	}
 	if err := os.RemoveAll(root); err != nil {
 		tb.Error(err)
 	}


### PR DESCRIPTION
Add rwx permission for 'noaccess' test dir, to allow recursive deletion
to succeed (needs read access in order to check if directory is empty; a
non-empty directory would also need at least write access).

os.RemoveAll() fails on at least MacOs without re-enabling these
permissions before attempting to remove 'noaccess' dir.

Fixes issue #23