### PR TITLE
IsDevice function

### DIFF
--- a/dirent.go
+++ b/dirent.go
@@ -57,6 +57,9 @@ func (de Dirent) IsRegular() bool { return de.modeType&os.ModeType == 0 }
 // set.
 func (de Dirent) IsSymlink() bool { return de.modeType&os.ModeSymlink != 0 }
 
+// IsDevice returns true if and only if the Dirent represents a device file.
+func (de Dirent) IsDevice() bool { return de.modeType&os.ModeDevice != 0 }
+
 // Dirents represents a slice of Dirent pointers, which are sortable by
 // name. This type satisfies the `sort.Interface` interface.
 type Dirents []*Dirent


### PR DESCRIPTION
This PR adds a `IsDevice()` function that increases ease of use of this package when walking a directory of devices.