### PR TITLE
Add helper function Dirent.FollowSymlink()

### DIFF
--- a/dirent.go
+++ b/dirent.go
@@ -6,9 +6,10 @@ import (
 	"path/filepath"
 )
 
-// Dirent stores the name and file system mode type of discovered file system
+// Dirent stores information about discovered file system
 // entries.
 type Dirent struct {
+	path     string
 	name     string
 	modeType os.FileMode
 }
@@ -25,10 +26,14 @@ func NewDirent(osPathname string) (*Dirent, error) {
 		return nil, err
 	}
 	return &Dirent{
+		path:     osPathname,
 		name:     filepath.Base(osPathname),
 		modeType: fi.Mode() & os.ModeType,
 	}, nil
 }
+
+// Path returns the original filepath used to create the filesystem entity
+func (de Dirent) Path() string { return de.path }
 
 // Name returns the basename of the file system entry.
 func (de Dirent) Name() string { return de.name }
@@ -67,12 +72,17 @@ func (de Dirent) FollowSymlink() (*Dirent, error) {
 		return &de, errors.New("Cannot Dirent.FollowSymlink() on non-symlink Dirent!")
 	}
 
-	resolvedPath, err := filepath.EvalSymlinks(de.name)
+	resolvedPath, err := filepath.EvalSymlinks(de.path)
 	if err != nil {
 		return &de, err
 	}
 
-	resolvedDe, err := NewDirent(resolvedPath)
+	absPath, err := filepath.Abs(resolvedPath)
+	if err != nil {
+		return &de, err
+	}
+
+	resolvedDe, err := NewDirent(absPath)
 	if err != nil {
 		return &de, err
 	}


### PR DESCRIPTION
Added a helper function for handling symlinks to Dirent. This function can be used as follows:

```go
    err := godirwalk.Walk("./example", &godirwalk.Options{
        FollowSymbolicLinks: true,
        Callback: func(path string, de *godirwalk.Dirent) error {
            if de.IsSymlink() {
                newDe, err := de.FollowSymlink()
                if err != nil {
                    return err
                }

                // go scoping requires that we set this separately
                de = newDe
            }

            log.WithFields(log.Fields{
                "path":      path,
                "IsRegular": de.IsRegular(),
                "IsDir":     de.IsDir(),
                "IsSymlink": de.IsSymlink(),
            }).Info("")

            return nil
        },
    })
```

This is useful because without following the symlink via filepath.EvalSymlinks() and creating a new Dirent, then the original Dirent on some systems will return de.IsSymlink() // true and de.IsDir() // false and de.IsRegular() // false, which can cause accidental mistakes. By using de.FollowSymlink() you can then be confident that de.IsDir() and de.IsRegular() will now return stat information about the followed symlink.

This PR also includes adding `Dirent.Path()` and `Dirent.path` to support absolute paths when following the symlink.

Note: There exists a subtle flaw in that you can't reassign and initialize a variable in the same := or = in golang, so instead these must be separated out. :/ The other option is to pre-declare both variables such as var err error or adding it to the function proto.