### PR TITLE
use syscall.Dirent.Namlen on dragonfly for reclen

### DIFF
--- a/inoWithIno.go
+++ b/inoWithIno.go
@@ -5,6 +5,5 @@ package godirwalk
 import "syscall"
 
 func inoFromDirent(de *syscall.Dirent) uint64 {
-	// cast necessary on file systems that store ino as different type
 	return uint64(de.Ino)
 }

--- a/reclenFromNamlen.go
+++ b/reclenFromNamlen.go
@@ -1,0 +1,9 @@
+// +build dragonfly
+
+package godirwalk
+
+import "syscall"
+
+func reclen(de *syscall.Dirent) uint64 {
+	return (16 + uint64(de.Namlen) + 1 + 7) &^ 7
+}

--- a/reclenFromReclen.go
+++ b/reclenFromReclen.go
@@ -4,6 +4,6 @@ package godirwalk
 
 import "syscall"
 
-func direntReclen(de *syscall.Dirent, _ uint64) uint64 {
+func reclen(de *syscall.Dirent) uint64 {
 	return uint64(de.Reclen)
 }

--- a/scandir_unix.go
+++ b/scandir_unix.go
@@ -143,15 +143,14 @@ func (s *Scanner) Scan() bool {
 		// in the work buffer.
 		for len(s.workBuffer) > 0 {
 			s.sde = (*syscall.Dirent)(unsafe.Pointer(&s.workBuffer[0])) // point entry to first syscall.Dirent in buffer
-
-			nameSlice := nameFromDirent(s.sde)
-			nameLength := len(nameSlice)
-
-			s.workBuffer = s.workBuffer[direntReclen(s.sde, uint64(nameLength)):] // advance buffer for next iteration through loop
+			s.workBuffer = s.workBuffer[reclen(s.sde):]                 // advance buffer for next iteration through loop
 
 			if inoFromDirent(s.sde) == 0 {
 				continue // inode set to 0 indicates an entry that was marked as deleted
 			}
+
+			nameSlice := nameFromDirent(s.sde)
+			nameLength := len(nameSlice)
 
 			if nameLength == 0 || (nameSlice[0] == '.' && (nameLength == 1 || (nameLength == 2 && nameSlice[1] == '.'))) {
 				continue

--- a/withoutReclen.go
+++ b/withoutReclen.go
@@ -1,9 +1,0 @@
-// +build dragonfly
-
-package godirwalk
-
-import "syscall"
-
-func direntReclen(_ *syscall.Dirent, nameLength uint64) uint64 {
-	return (16 + nameLength + 1 + 7) &^ 7
-}


### PR DESCRIPTION
Eliminates creation of name string when inode or fileno is 0.

Cleaner dragonfly implementation.