### PR TITLE
Performance on Windows

### DIFF
--- a/scandir_unix.go
+++ b/scandir_unix.go
@@ -54,7 +54,7 @@ func NewScanner(osDirname string) (*Scanner, error) {
 
 // NewScannerWithScratchBuffer returns a new directory Scanner that lazily
 // enumerates the contents of a single directory. On platforms other than
-// Windows it ues the provided scratch buffer to read from the file system. On
+// Windows it uses the provided scratch buffer to read from the file system. On
 // Windows the scratch buffer is ignored.
 func NewScannerWithScratchBuffer(osDirname string, scratchBuffer []byte) (*Scanner, error) {
 	dh, err := os.Open(osDirname)

--- a/scandir_windows.go
+++ b/scandir_windows.go
@@ -57,7 +57,7 @@ func NewScanner(osDirname string) (*Scanner, error) {
 
 // NewScannerWithScratchBuffer returns a new directory Scanner that lazily
 // enumerates the contents of a single directory. On platforms other than
-// Windows it ues the provided scratch buffer to read from the file system. On
+// Windows it uses the provided scratch buffer to read from the file system. On
 // Windows the scratch buffer parameter is ignored.
 func NewScannerWithScratchBuffer(osDirname string, scratchBuffer []byte) (*Scanner, error) {
 	return NewScanner(osDirname)


### PR DESCRIPTION
  Expect a rather large performance improvement for ReadDirents and
  ReadDirnames for Windows. No longer uses Scanner, but requests list of
  all directory children and returns to caller.
