### PR TITLE
re-issue syscall request after EINTR

### DIFF
--- a/readdir_unix.go
+++ b/readdir_unix.go
@@ -36,6 +36,9 @@ func readDirents(osDirname string, scratchBuffer []byte) ([]*Dirent, error) {
 			n, err := syscall.ReadDirent(fd, scratchBuffer)
 			// n, err := unix.ReadDirent(fd, scratchBuffer)
 			if err != nil {
+				if err == syscall.EINTR /* || err == unix.EINTR */ {
+					continue
+				}
 				_ = dh.Close()
 				return nil, err
 			}
@@ -92,6 +95,9 @@ func readDirnames(osDirname string, scratchBuffer []byte) ([]string, error) {
 			n, err := syscall.ReadDirent(fd, scratchBuffer)
 			// n, err := unix.ReadDirent(fd, scratchBuffer)
 			if err != nil {
+				if err == syscall.EINTR /* || err == unix.EINTR */ {
+					continue
+				}
 				_ = dh.Close()
 				return nil, err
 			}
@@ -104,9 +110,9 @@ func readDirnames(osDirname string, scratchBuffer []byte) ([]string, error) {
 			workBuffer = scratchBuffer[:n] // trim work buffer to number of bytes read
 		}
 
-		// Handle first entry in the work buffer.
 		sde = (*syscall.Dirent)(unsafe.Pointer(&workBuffer[0])) // point entry to first syscall.Dirent in buffer
-		workBuffer = workBuffer[reclen(sde):]                   // advance buffer for next iteration through loop
+		// Handle first entry in the work buffer.
+		workBuffer = workBuffer[reclen(sde):] // advance buffer for next iteration through loop
 
 		if inoFromDirent(sde) == 0 {
 			continue // inode set to 0 indicates an entry that was marked as deleted

--- a/scandir_unix.go
+++ b/scandir_unix.go
@@ -131,6 +131,9 @@ func (s *Scanner) Scan() bool {
 			n, err := syscall.ReadDirent(s.fd, s.scratchBuffer)
 			// n, err := unix.ReadDirent(s.fd, s.scratchBuffer)
 			if err != nil {
+				if err == syscall.EINTR /* || err == unix.EINTR */ {
+					continue
+				}
 				s.done(err)
 				return false
 			}


### PR DESCRIPTION
  More resiliant when on Go v1.14, where syscall is more likely to
  return syscall.EINTR.

  Also, alongside the place where it would instead call
  golang.org/x/sys/unix, but it is commented out, I include the
  equivalent code for checking for unix.EINTR, to make it less likely
  that I forget to change the EINTR check if I ever convert it to use
  golang.org/x/sys/unix rather than syscall.