### PR TITLE
Callback returns godirwalk.SkipThis to skip entry

### DIFF
--- a/examples/find-fast/main.go
+++ b/examples/find-fast/main.go
@@ -55,9 +55,12 @@ func main() {
 	switch {
 	case nameRE == nil:
 		// When no name pattern provided, print everything.
-		options.Callback = func(osPathname string, _ *godirwalk.Dirent) error {
+		options.Callback = func(osPathname string, de *godirwalk.Dirent) error {
 			if *optSkip != "" && strings.Contains(osPathname, *optSkip) {
-				return filepath.SkipDir
+				if !*optQuiet {
+					fmt.Fprintf(os.Stderr, "%s: %s (skipping)\n", programName, osPathname)
+				}
+				return godirwalk.SkipThis
 			}
 			_, err := fmt.Println(osPathname)
 			return err
@@ -66,7 +69,10 @@ func main() {
 		// Name pattern was provided, but color not permitted.
 		options.Callback = func(osPathname string, _ *godirwalk.Dirent) error {
 			if *optSkip != "" && strings.Contains(osPathname, *optSkip) {
-				return filepath.SkipDir
+				if !*optQuiet {
+					fmt.Fprintf(os.Stderr, "%s: %s (skipping)\n", programName, osPathname)
+				}
+				return godirwalk.SkipThis
 			}
 			var err error
 			if nameRE.FindString(osPathname) != "" {
@@ -80,7 +86,10 @@ func main() {
 
 		options.Callback = func(osPathname string, _ *godirwalk.Dirent) error {
 			if *optSkip != "" && strings.Contains(osPathname, *optSkip) {
-				return filepath.SkipDir
+				if !*optQuiet {
+					fmt.Fprintf(os.Stderr, "%s: %s (skipping)\n", programName, osPathname)
+				}
+				return godirwalk.SkipThis
 			}
 			matches := nameRE.FindAllStringSubmatchIndex(osPathname, -1)
 			if len(matches) == 0 {

--- a/walk_test.go
+++ b/walk_test.go
@@ -136,6 +136,44 @@ func TestWalkSkipDir(t *testing.T) {
 	})
 }
 
+func TestWalkSkipThis(t *testing.T) {
+	t.Run("SkipThis", func(t *testing.T) {
+		var actual []string
+		err := Walk(filepath.Join(scaffolingRoot, "d0"), &Options{
+			Callback: func(osPathname string, dirent *Dirent) error {
+				switch name := dirent.Name(); name {
+				case "skips", "skip", "nothing":
+					return SkipThis
+				}
+				actual = append(actual, filepath.FromSlash(osPathname))
+				return nil
+			},
+			FollowSymbolicLinks: true,
+		})
+
+		ensureError(t, err)
+
+		expected := []string{
+			filepath.Join(scaffolingRoot, "d0"),
+			filepath.Join(scaffolingRoot, "d0/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
+			filepath.Join(scaffolingRoot, "d0/f1"),
+			filepath.Join(scaffolingRoot, "d0/d1"),
+			filepath.Join(scaffolingRoot, "d0/d1/f2"),
+			filepath.Join(scaffolingRoot, "d0/symlinks"),
+			filepath.Join(scaffolingRoot, "d0/symlinks/d4"),
+			filepath.Join(scaffolingRoot, "d0/symlinks/d4/toSD1"),
+			filepath.Join(scaffolingRoot, "d0/symlinks/d4/toSD1/f2"),
+			filepath.Join(scaffolingRoot, "d0/symlinks/d4/toSF1"),
+			filepath.Join(scaffolingRoot, "d0/symlinks/toAbs"),
+			filepath.Join(scaffolingRoot, "d0/symlinks/toD1"),
+			filepath.Join(scaffolingRoot, "d0/symlinks/toD1/f2"),
+			filepath.Join(scaffolingRoot, "d0/symlinks/toF1"),
+		}
+
+		ensureStringSlicesMatch(t, actual, expected)
+	})
+}
+
 func TestWalkFollowSymbolicLinks(t *testing.T) {
 	var actual []string
 	var errorCallbackVisited bool


### PR DESCRIPTION
One arguably confusing aspect of the filepath.WalkFunc API that this library
must emulate is how a caller tells Walk to skip file system entries or
directories. With both filepath.Walk and this Walk, when a callback function
wants to skip a directory and not descend into its children, it returns
filepath.SkipDir. If the callback function returns filepath.SkipDir for a
non-directory, filepath.Walk and this library will stop processing any more
entries in the current directory, which is what many people do not want. If
you want to simply skip a particular non-directory entry but continue
processing entries in the directory, a callback function must return nil. The
implications of this API is when you want to walk a file system hierarchy and
skip an entry, when the entry is a directory, you must return one value,
namely filepath.SkipDir, but when the entry is a non-directory, you must
return a different value, namely nil. In other words, to get identical
behavior for two file system entry types you need to send different token
values.

Here is an example callback function that adheres to filepath.Walk API to
have it skip any file system entry whose full pathname includes a particular
substring, optSkip:

    func callback1(osPathname string, de *godirwalk.Dirent) error {
        if optSkip != "" && strings.Contains(osPathname, optSkip) {
            if b, err := de.IsDirOrSymlinkToDir(); b == true && err == nil {
                return filepath.SkipDir
            }
            return nil
        }
        // Process file like normal...
        return nil
    }

This library attempts to eliminate some of that logic boilerplate by
providing a new token error value, SkipThis, which a callback function may
return to skip the current file system entry regardless of what type of entry
it is. If the current entry is a directory, its children will not be
enumerated, exactly as if the callback returned filepath.SkipDir. If the
current entry is a non-directory, the next file system entry in the current
directory will be enumerated, exactly as if the callback returned nil. The
following example callback function has identical behavior as the previous,
but has less boilerplate, and admittedly more simple logic.

    func callback2(osPathname string, de *godirwalk.Dirent) error {
        if optSkip != "" && strings.Contains(osPathname, optSkip) {
            return godirwalk.SkipThis
        }
        // Process file like normal...
        return nil
    }