### PR TITLE
fix: ignore EOF error on Windows directory scanning

### DIFF
--- a/scandir_windows.go
+++ b/scandir_windows.go
@@ -133,6 +133,11 @@ func (s *Scanner) Scan() bool {
 
 	fileinfos, err := s.dh.Readdir(1)
 	if err != nil {
+		// Readdir returns io.EOF at the end of a directory
+		if err == io.EOF {
+			s.done(nil)
+			return false
+		}
 		s.done(err)
 		return false
 	}

--- a/scandir_windows.go
+++ b/scandir_windows.go
@@ -5,6 +5,7 @@ package godirwalk
 
 import (
 	"fmt"
+	"io"
 	"os"
 )
 


### PR DESCRIPTION
In #68, the scanner now returns any error that was encountered. On Windows, the call to [Readdir](https://pkg.go.dev/os#File.Readdir) will return an EOF when it is done reading a directory.

I believe the desired behavior is to throw an error on any actual errors, but in the case of EOF, continue on to the next directory. As such, check for the EOF and return no error while releasing resources.

A user can test this PR by using the walk-fast example:

```
go run ./examples/walk-fast/main.go --verbose C:/users/powersj/godirwalk
```

Currently, this will throw an EOF error after the first directory. With this fix, all the sub-directories will be traversed and return successfully.

fixes: #70